### PR TITLE
Responsive text/margin scaling

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ site.title }}</title>
   <link rel="shortcut icon" href="/favicon.ico">
-  {% include style.html %}
+  <link rel="stylesheet" href="main.css">
 </head>
 <body>
   <div class="container">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page.title }} | {{ site.title }}</title>
   <link rel="shortcut icon" href="/favicon.ico">
-  {% include style.html %}
+  <link rel="stylesheet" href="main.css">
 </head>
 <body>
   <div class="container">

--- a/main.css
+++ b/main.css
@@ -5,17 +5,31 @@
 
  body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 1.25em;
+  font-size: 100%;
   line-height: 1.5;
  }
 
  .container {
-   max-width: 40rem;
+   max-width: 32rem;
    padding-left: 1rem;
    padding-right: 1rem;
    margin-left: auto;
    margin-right: auto;
  }
+
+/* Big text for big windows */
+@media (min-width: 513px) {
+  html { font-size: 125%; }
+  small, footer { font-size: 0.8em; }
+}
+
+/*Less whitespace for tiny windows*/
+@media (max-width: 320px) {
+  .container { padding: 0 0.5rem; }
+  h1, h2, h3, h4, h5, h6, p, ul { margin: 0.75rem 0; }
+  p { margin: 0.5rem 0; }
+  ul { padding-left: 1em; }
+}
 
  h1, h2, h3, h4, h5, h6 {
    line-height: 1.2;
@@ -26,7 +40,7 @@
    Link colors are unset to maintain footer blandness. */
  footer {
    opacity: 0.5;
-   font-size: 0.8em;
+   font-size: 0.875em;
    text-align: center;
    margin-bottom: 2rem;
  }
@@ -43,7 +57,7 @@
  }
  form small {
    display: block;
-   font-size: 0.8em;
+   font-size: 0.875em;
  }
  form label textarea {
    display: block;

--- a/main.css
+++ b/main.css
@@ -26,8 +26,6 @@
 /*Less whitespace for tiny windows*/
 @media (max-width: 320px) {
   .container { padding: 0 0.5rem; }
-  h1, h2, h3, h4, h5, h6, p, ul { margin: 0.75rem 0; }
-  p { margin: 0.5rem 0; }
   ul { padding-left: 1em; }
 }
 

--- a/main.css
+++ b/main.css
@@ -19,8 +19,8 @@
 
 /* Big text for big windows */
 @media (min-width: 513px) {
-  html { font-size: 125%; }
-  small, footer { font-size: 0.8em; }
+  html { font-size: 125%; } /*20px, when the original size is 16px*/
+  small, footer { font-size: 0.8em; } /*reciprocal of 1.25*/
 }
 
 /*Less whitespace for tiny windows*/
@@ -40,7 +40,7 @@
    Link colors are unset to maintain footer blandness. */
  footer {
    opacity: 0.5;
-   font-size: 0.875em;
+   font-size: 0.875em; /*14px, when 1em is 16px*/
    text-align: center;
    margin-bottom: 2rem;
  }

--- a/main.css
+++ b/main.css
@@ -1,5 +1,3 @@
-<style>
-
 /* This website has no colors set,
    because colors should be consistently either set or unset.
 
@@ -51,5 +49,3 @@
    display: block;
    width: 100%;
  }
-
-</style>


### PR DESCRIPTION
Makes text size and margin change at 3 breakpoints:

- For windows 513px wide and wider, layout is unchanged: normal margins, 20px base font size, 16px font size for small text, etc
- For windows between 321px and 512px wide, or browsers not supporting @media queries, text is smaller but margins remain constant (relative to font size: 16px base font size, 14px font size for small text)
- For windows 320px wide or narrower, the base font size is still 16px with small text at 14px, but the padding for the entire page has shrunk, as has list padding.

Additionally, styling has been moved to an actual stylesheet instead of being inline.